### PR TITLE
update SpringContext to be more Kotlin-like

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ build/
 **/.DS_Store
 logs/
 application.pid
+.junie/
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <springdoc.version>2.8.9</springdoc.version>
         <mockk.version>1.14.11</mockk.version>
         <tomcat.version>11.0.22</tomcat.version>
+        <mockito.version>5.23.0</mockito.version>
         <argLine/>
     </properties>
     <dependencies>
@@ -261,17 +262,39 @@
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
                 <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/target/generated-sources/annotations</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/target/generated-test-sources/test-annotations</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
                     <languageVersion>2.4</languageVersion>
                     <apiVersion>2.4</apiVersion>
-                    <sourceDirs>
-                        <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                        <source>target/generated-sources/annotations</source>
-                    </sourceDirs>
-                    <jvmTarget>21</jvmTarget>
+                    <jvmTarget>25</jvmTarget>
                     <compilerPlugins>
                         <plugin>kotlinx-serialization</plugin>
                         <plugin>spring</plugin>

--- a/src/main/kotlin/xyz/jimh/souschef/config/Preferences.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/config/Preferences.kt
@@ -191,7 +191,7 @@ object Preferences : Broadcaster() {
 
     private fun loadPreferenceDao(): PreferenceDao {
         if (!this::preferenceDao.isInitialized) {
-            preferenceDao = SpringContext.getBean(PreferenceDao::class.java)
+            preferenceDao = SpringContext.getBean()
         }
         return preferenceDao
     }

--- a/src/main/kotlin/xyz/jimh/souschef/config/SpringContext.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/config/SpringContext.kt
@@ -5,7 +5,7 @@
 
 package xyz.jimh.souschef.config
 
-import org.springframework.beans.factory.getBean
+import org.springframework.beans.BeansException
 import org.springframework.context.ApplicationContext
 import org.springframework.stereotype.Component
 
@@ -17,6 +17,13 @@ class SpringContext(val context: ApplicationContext) {
 
     companion object {
         lateinit var instance: SpringContext
-        inline fun <reified T : Any> getBean(): T = instance.context.getBean()
+
+        /**
+         * Returns a bean by its class [T].
+         *
+         * @throws IllegalStateException if applicationContext is not initialized
+         * @throws BeansException if bean cannot be loaded
+         */
+        inline fun <reified T : Any> getBean(): T = instance.context.getBean(T::class.java)
     }
 }

--- a/src/main/kotlin/xyz/jimh/souschef/config/SpringContext.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/config/SpringContext.kt
@@ -5,37 +5,18 @@
 
 package xyz.jimh.souschef.config
 
-import org.springframework.beans.BeansException
+import org.springframework.beans.factory.getBean
 import org.springframework.context.ApplicationContext
-import org.springframework.context.ApplicationContextAware
 import org.springframework.stereotype.Component
 
-/**
- * Object that allows a non-bean to access a bean.
- */
 @Component
-object SpringContext : ApplicationContextAware {
-
-    private lateinit var appContext: ApplicationContext
-
-    /**
-     * Called automatically at app startup to supply the [ApplicationContext]
-     */
-    override fun setApplicationContext(applicationContext: ApplicationContext) {
-        appContext = applicationContext
+class SpringContext(val context: ApplicationContext) {
+    init {
+        instance = this
     }
 
-    /**
-     * Returns a bean by its class [clazz].
-     *
-     * @throws IllegalStateException if applicationContext is not initialized
-     * @throws BeansException if bean cannot be loaded
-     */
-    @Throws(BeansException::class, IllegalStateException::class)
-    fun <T : Any> getBean(clazz: Class<T>): T {
-        check(this::appContext.isInitialized) {
-            "Spring context has not been initialized; getting bean of type ${clazz.simpleName}"
-        }
-        return appContext.getBean(clazz)
+    companion object {
+        lateinit var instance: SpringContext
+        inline fun <reified T : Any> getBean(): T = instance.context.getBean()
     }
 }

--- a/src/main/kotlin/xyz/jimh/souschef/control/EditRecipeController.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/control/EditRecipeController.kt
@@ -420,7 +420,7 @@ class EditRecipeController(
         val errors = checkErrors(recipe)
         if (errors.isNotEmpty()) {
             val jsonErrors: String = Json.encodeToString(errors)
-            throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, jsonErrors)
+            throw ResponseStatusException(HttpStatus.UNPROCESSABLE_CONTENT, jsonErrors)
         }
         val categoryOptional = categoryDao.findByName(recipe.category)
         val category = when {

--- a/src/main/kotlin/xyz/jimh/souschef/control/EditRecipeController.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/control/EditRecipeController.kt
@@ -13,7 +13,6 @@ import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 import jakarta.servlet.http.HttpServletRequest
 import java.util.Collections.singletonMap
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType

--- a/src/main/kotlin/xyz/jimh/souschef/control/RecipeListController.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/control/RecipeListController.kt
@@ -13,7 +13,7 @@ import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 import jakarta.servlet.http.HttpServletRequest
 import java.time.Instant
-import java.util.*
+import java.util.Optional
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType

--- a/src/main/kotlin/xyz/jimh/souschef/control/ShowRecipeController.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/control/ShowRecipeController.kt
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 import jakarta.servlet.http.HttpServletRequest
-import java.util.*
+import java.util.Collections
 import mu.KotlinLogging
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/xyz/jimh/souschef/data/RecipeDao.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/data/RecipeDao.kt
@@ -6,7 +6,7 @@
 package xyz.jimh.souschef.data
 
 import io.swagger.v3.oas.annotations.Hidden
-import java.util.*
+import java.util.Optional
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 

--- a/src/main/kotlin/xyz/jimh/souschef/display/HtmlBuilder.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/display/HtmlBuilder.kt
@@ -5,7 +5,7 @@
 
 package xyz.jimh.souschef.display
 
-import java.util.*
+import java.util.Stack
 
 /**
  * Class that builds an HTML document. The header and body are built

--- a/src/main/kotlin/xyz/jimh/souschef/display/HtmlElements.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/display/HtmlElements.kt
@@ -65,10 +65,10 @@ object HtmlElements {
 
     private fun loadControllers() {
         if (!this::recipeController.isInitialized) {
-            recipeController = SpringContext.getBean(RecipeController::class.java)
+            recipeController = SpringContext.getBean()
         }
         if (!this::categoryController.isInitialized) {
-            categoryController = SpringContext.getBean(CategoryController::class.java)
+            categoryController = SpringContext.getBean()
         }
     }
 

--- a/src/main/kotlin/xyz/jimh/souschef/display/IngredientBuilder.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/display/IngredientBuilder.kt
@@ -105,19 +105,19 @@ object IngredientBuilder {
 
     private fun loadCategoryDao() {
         if (!this::categoryDao.isInitialized) {
-            categoryDao = SpringContext.getBean(CategoryDao::class.java)
+            categoryDao = SpringContext.getBean()
         }
     }
 
     private fun loadIngredientFormatter() {
         if (!this::ingredientFormatter.isInitialized) {
-            ingredientFormatter = SpringContext.getBean(IngredientFormatter::class.java)
+            ingredientFormatter = SpringContext.getBean()
         }
     }
 
     private fun loadUnitController() {
         if (!this::unitController.isInitialized) {
-            unitController = SpringContext.getBean(UnitController::class.java)
+            unitController = SpringContext.getBean()
         }
     }
 }

--- a/src/main/kotlin/xyz/jimh/souschef/parse/IngredientParser.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/parse/IngredientParser.kt
@@ -167,7 +167,7 @@ class IngredientParser(aLine: String) {
 
         internal fun loadUnitController() {
             if (!this::unitDao.isInitialized) {
-                unitDao = SpringContext.getBean(UnitDao::class.java)
+                unitDao = SpringContext.getBean()
             }
             if (units.isEmpty()) {
                 units.addAll(unitDao.findAll())

--- a/src/main/kotlin/xyz/jimh/souschef/parse/RecipeParser.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/parse/RecipeParser.kt
@@ -40,7 +40,7 @@ const val BUFFER_SIZE = 1 shl 18    // 256k bytes
 
 
 /**
- * Controller class that handles actually parsing a recipe, and displaying the page where it's entered.
+ * Controller class that handles actually parsing a recipe and displaying the page where it's entered.
  */
 @RestController
 class RecipeParser(private val ingredientFormatter: IngredientFormatter) {
@@ -152,7 +152,7 @@ class RecipeParser(private val ingredientFormatter: IngredientFormatter) {
     }
 
     /**
-     * Attempts to read a file chosen by the client, and parse out a recipe. This function recognizes
+     * Attempts to read a file chosen by the client and parse out a recipe. This function recognizes
      * the following media types:
      * 1. text/plain; and
      * 1. application/pdf
@@ -222,7 +222,7 @@ class RecipeParser(private val ingredientFormatter: IngredientFormatter) {
             ResponseEntity.ok(readPdfText(content))
         } catch (e: Exception) {
             kLogger.warn(e) { "Failed to read pdf text ${e.message}\n${e.stackTraceToString()}" }
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).build()
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT).build()
         }
     }
 
@@ -244,9 +244,9 @@ class RecipeParser(private val ingredientFormatter: IngredientFormatter) {
      * Read the recipe and separate it into parts.
      * Assumptions:
      *     1. The first line is the recipe title.
-     *     2. The next lines are ingredients, which have format number [unit] ingredient
+     *     2. The next lines are ingredients, which have format number \[unit] ingredient
      *     3. At some point, there <em>might be</em> a number of servings
-     *     4. finally, directions.
+     *     4. Finally, directions.
      */
     private fun parseRecipe(reader: Reader, html: HtmlBuilder, remoteHost: String) {
         html.addHeaderWhitespace().addHeaderElement("style")
@@ -262,7 +262,7 @@ class RecipeParser(private val ingredientFormatter: IngredientFormatter) {
             // title
             parseTitle(bReader, html)
 
-            // servings: Try to find a line with number of servings info.  Mark the stream to this position.
+            // servings: Try to find a line with "number of servings" info.  Mark the stream to this position.
             val servesString = Preferences.getLanguageString("Serves")
             val servingsString = Preferences.getLanguageString("Servings")
             val serves = findServings(bReader, servesString, servingsString)

--- a/src/main/kotlin/xyz/jimh/souschef/utility/VulgarFractions.kt
+++ b/src/main/kotlin/xyz/jimh/souschef/utility/VulgarFractions.kt
@@ -21,6 +21,9 @@ import xyz.jimh.souschef.parse.NumberReader.ST_THREE_SEVENTHS
 import xyz.jimh.souschef.parse.NumberReader.ST_THREE_TENTHS
 import xyz.jimh.souschef.parse.NumberReader.ST_TWO_NINTHS
 import xyz.jimh.souschef.parse.NumberReader.ST_TWO_SEVENTHS
+import xyz.jimh.souschef.utility.VulgarFractions.CH_ONE_HALF
+import xyz.jimh.souschef.utility.VulgarFractions.ONE_HALF
+import xyz.jimh.souschef.utility.VulgarFractions.ST_ONE_HALF
 
 /**
  * Object holding constants for all Unicode vulgar fractions commonly used in recipes both as

--- a/src/test/kotlin/xyz/jimh/souschef/ControllerTestBase.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/ControllerTestBase.kt
@@ -32,11 +32,8 @@ open class ControllerTestBase {
         every { request.remoteHost } returns "localhost"
         every { request.requestURL } returns StringBuffer("http://localhost/souschef/test")
 
-        applicationContext = mockk()
-
-        context = mockk()
-        every { context.setApplicationContext(applicationContext) } answers { callOriginal() }
-        context.setApplicationContext(applicationContext)
+        applicationContext = mockk(relaxed = true)
+        context = SpringContext(applicationContext)
     }
 
     protected fun teardownContext() {

--- a/src/test/kotlin/xyz/jimh/souschef/config/ConfigUtility.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/config/ConfigUtility.kt
@@ -5,14 +5,21 @@
 
 package xyz.jimh.souschef.config
 
-import org.jetbrains.kotlin.builtins.StandardNames.FqNames
-
 // Kluge to "uninitialize" the lateinit field
 fun resetLateInitField(target: Any, fieldName: String) {
-    val field = target.javaClass.getDeclaredField(fieldName)
-    with (field) {
-        isAccessible = true
-        set(FqNames.target, null)
+    val clazz = if (target is Class<*>) target else target.javaClass
+    val field = try {
+        clazz.getDeclaredField(fieldName)
+    } catch (e: NoSuchFieldException) {
+        // If it's a companion object property, it might be in the outer class
+        if (clazz.name.endsWith("$" + "Companion")) {
+            val outerClassName = clazz.name.substringBefore("$" + "Companion")
+            Class.forName(outerClassName).getDeclaredField(fieldName)
+        } else {
+            throw e
+        }
     }
+    field.isAccessible = true
+    field.set(if (java.lang.reflect.Modifier.isStatic(field.modifiers)) null else target, null)
 }
 

--- a/src/test/kotlin/xyz/jimh/souschef/config/PreferencesTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/config/PreferencesTest.kt
@@ -47,8 +47,7 @@ class PreferencesTest {
 
         every { request.remoteHost } returns "localhost"
 
-        every { context.setApplicationContext(any()) } answers { callOriginal() }
-        context.setApplicationContext(applicationContext)
+        SpringContext.instance = SpringContext(applicationContext)
         Preferences.preferenceDao = preferenceDao
         Preferences.locale = "en_US"
 
@@ -64,8 +63,6 @@ class PreferencesTest {
             { assertNotNull(body) },
             { assertEquals("valid", response.body) },
         )
-
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
@@ -76,8 +73,6 @@ class PreferencesTest {
             { assertEquals(HttpStatus.NOT_FOUND, response.statusCode) },
             { assertNull(body) },
         )
-
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
@@ -98,13 +93,11 @@ class PreferencesTest {
             { assertTrue(scriptEnd > scriptStart, "script end after start") },
             { assertTrue(html.contains("<head>"), "head exists") },
         )
-
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
     fun getPreferenceValues() {
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
         val prefs = Preferences.getPreferenceValues(request)
         assertNotNull(prefs)
         assertAll(
@@ -116,7 +109,6 @@ class PreferencesTest {
 
         verify(exactly = 1) { preferenceDao.findAllByHost("localhost") }
         verify { request.remoteHost }
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
@@ -162,7 +154,6 @@ class PreferencesTest {
             { assertNull(Preferences.getPreference("remote", "anything")) },
         )
 
-        verify(exactly = 1) { context.setApplicationContext(any()) }
         verify(exactly = 6) { request.remoteHost }
         verify(exactly = 7) { preferenceDao.save(allAny()) }
         verify(exactly = 12) { preferenceDao.findByHostAndKey("localhost", allAny()) }
@@ -220,12 +211,11 @@ class PreferencesTest {
             preferenceDao.delete(allAny())
         }
         verify { request.remoteHost }
-        verify { context.setApplicationContext(allAny()) }
     }
 
     @Test
     fun getPreference() {
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
         every { preferenceDao.findByHostAndKey("host", "key") } returns
                 Optional.of(Preference("host", "key", "key_host"))
         every { preferenceDao.findByHostAndKey("localhost", "other") } returns
@@ -237,12 +227,11 @@ class PreferencesTest {
         )
 
         verify(exactly = 2) { preferenceDao.findByHostAndKey(any(), any()) }
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
     fun getUnitTypes() {
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
         every { preferenceDao.findByHostAndKey("host1", any()) } returns
                 Optional.of(Preference("host1", "unit", "english"))
         every { preferenceDao.findByHostAndKey("host2", any()) } returns
@@ -262,12 +251,11 @@ class PreferencesTest {
         )
 
         verify(exactly = 5) { preferenceDao.findByHostAndKey(any(), any()) }
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
     fun getUnitNames() {
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
         every { preferenceDao.findByHostAndKey("host1", any()) } returns
                 Optional.of(Preference("host1", "unit", "full"))
         every { preferenceDao.findByHostAndKey("host2", any()) } returns
@@ -284,7 +272,6 @@ class PreferencesTest {
         )
 
         verify(exactly = 4) { preferenceDao.findByHostAndKey(any(), any()) }
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
@@ -293,8 +280,6 @@ class PreferencesTest {
         Preferences.addScripts(html, "fauxAlert.js")
 
         assertTrue(html.get().trim().contains("alert('nothing');"))
-
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
@@ -309,7 +294,6 @@ class PreferencesTest {
                 val response = Preferences.getPreferenceValues(request)
                 assertEquals(emptyMap(), response.body) }
         )
-        verify { context.setApplicationContext(any()) }
         verify { request.remoteHost }
         verify {
             preferenceDao.findByHostAndKey(allAny(), allAny())
@@ -321,7 +305,7 @@ class PreferencesTest {
     fun `preferencesDao is uninitialized`() {
         resetLateInitField(Preferences, "preferenceDao")
 
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
         every { preferenceDao.findByHostAndKey("host1", any()) } returns
                 Optional.of(Preference("host1", "unit", "full"))
         every { preferenceDao.findByHostAndKey("host2", any()) } returns
@@ -339,7 +323,6 @@ class PreferencesTest {
 
         verify { applicationContext.getBean(PreferenceDao::class.java) }
         verify(exactly = 4) { preferenceDao.findByHostAndKey(allAny(), allAny()) }
-        verify { context.setApplicationContext(any()) }
     }
 
     @Test
@@ -350,7 +333,6 @@ class PreferencesTest {
         assertThrows<UninitializedPropertyAccessException> { Preferences.preferenceDao.findAllByHost("remote") }
         assertThrows<UninitializedPropertyAccessException> { println(Preferences.locale) }
         assertThrows<UninitializedPropertyAccessException> { Preferences.languageStrings.get("locale") }
-        verify { context.setApplicationContext(allAny()) }
     }
 
     @Test
@@ -359,12 +341,11 @@ class PreferencesTest {
 
         resetLateInitField(Preferences, "locale")
         assertThrows<UninitializedPropertyAccessException>{ Preferences.initHtml() }
-        verify { context.setApplicationContext(allAny()) }
     }
 
     @AfterEach
     fun cleanup() {
-        confirmVerified(preferenceDao, applicationContext, request, context)
+        confirmVerified(preferenceDao, applicationContext, request)
         clearAllMocks()
     }
 }

--- a/src/test/kotlin/xyz/jimh/souschef/config/SpringContextTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/config/SpringContextTest.kt
@@ -7,7 +7,6 @@ package xyz.jimh.souschef.config
 
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -18,31 +17,28 @@ import xyz.jimh.souschef.data.CategoryDao
 
 class SpringContextTest {
 
-    private val springContext = SpringContext
     private lateinit var context: ApplicationContext
 
     @Test
     fun `getBean unavailable should throw exception`() {
-        context = mockk()
-        springContext.setApplicationContext(context)
+        context = mockk(relaxed = true)
+        SpringContext(context)
         every { context.getBean(CategoryDao::class.java) } throws NoSuchBeanDefinitionException("not found")
-        assertThrows<BeansException> { springContext.getBean(CategoryDao::class.java) }
-        verify { springContext.getBean(CategoryDao::class.java) }
+        assertThrows<BeansException> { SpringContext.getBean<CategoryDao>() }
     }
 
     @Test
     fun `getBean succeeds`() {
-        context = mockk()
-        springContext.setApplicationContext(context)
+        context = mockk(relaxed = true)
+        SpringContext(context)
         val categoryDao: CategoryDao = mockk()
         every { context.getBean(CategoryDao::class.java) } returns categoryDao
-        assertNotNull(context.getBean(CategoryDao::class.java))
-        verify { springContext.getBean(CategoryDao::class.java) }
+        assertNotNull(SpringContext.getBean<CategoryDao>())
     }
 
     @Test
     fun `context has not been set`() {
-        resetLateInitField(SpringContext, "appContext")
-        assertThrows<IllegalStateException> { springContext.getBean(CategoryDao::class.java) }
+        resetLateInitField(SpringContext, "instance")
+        assertThrows<UninitializedPropertyAccessException> { SpringContext.getBean<CategoryDao>() }
     }
 }

--- a/src/test/kotlin/xyz/jimh/souschef/control/EditRecipeControllerTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/control/EditRecipeControllerTest.kt
@@ -11,7 +11,8 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import java.util.*
+import java.util.Locale
+import java.util.Optional
 import kotlin.test.DefaultAsserter.fail
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -357,7 +358,7 @@ class EditRecipeControllerTest : ControllerTestBase() {
         } catch (e: ResponseStatusException) {
             val body = e.message
             assertAll(
-                { assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.statusCode) },
+                { assertEquals(HttpStatus.UNPROCESSABLE_CONTENT, e.statusCode) },
                 { assertNotNull(body) },
                 { assertTrue(body.contains(EditRecipeController.NO_RECIPE_NAME)) },
                 { assertTrue(body.contains(EditRecipeController.NO_INGREDIENTS)) },
@@ -382,7 +383,7 @@ class EditRecipeControllerTest : ControllerTestBase() {
         } catch (e: ResponseStatusException) {
             val body = e.message
             assertAll(
-                { assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.statusCode) },
+                { assertEquals(422, e.statusCode.value()) },
                 { assertNotNull(body) },
                 { assertFalse(body.contains(EditRecipeController.NO_RECIPE_NAME), "name") },
                 { assertTrue(body.contains(EditRecipeController.NO_INGREDIENTS), "ingredients") },

--- a/src/test/kotlin/xyz/jimh/souschef/control/RecipeListControllerTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/control/RecipeListControllerTest.kt
@@ -26,7 +26,6 @@ import xyz.jimh.souschef.ControllerTestBase
 import xyz.jimh.souschef.config.Broadcaster
 import xyz.jimh.souschef.config.Listener
 import xyz.jimh.souschef.config.Preferences
-import xyz.jimh.souschef.config.SpringContext
 import xyz.jimh.souschef.data.Category
 import xyz.jimh.souschef.data.CategoryDao
 import xyz.jimh.souschef.data.Preference
@@ -51,7 +50,7 @@ class RecipeListControllerTest : ControllerTestBase() {
         preferenceDao = mockk()
         Preferences.preferenceDao = preferenceDao
         every { preferenceDao.findAllByHost("localhost") } returns prefList
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
         every { categoryDao.findAll() } returns categoryList.toMutableList()
 
         Preferences.locale = "en_US"

--- a/src/test/kotlin/xyz/jimh/souschef/control/SearchControllerTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/control/SearchControllerTest.kt
@@ -112,7 +112,7 @@ class SearchControllerTest : ApplicationContextAware {
 
     override fun setApplicationContext(applicationContext: ApplicationContext) {
         appContext = applicationContext
-        SpringContext.setApplicationContext(appContext)
+        SpringContext(appContext)
     }
 
     fun inserts() {

--- a/src/test/kotlin/xyz/jimh/souschef/control/ShowRecipeControllerTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/control/ShowRecipeControllerTest.kt
@@ -21,7 +21,6 @@ import xyz.jimh.souschef.ControllerTestBase
 import xyz.jimh.souschef.config.Broadcaster
 import xyz.jimh.souschef.config.Listener
 import xyz.jimh.souschef.config.Preferences
-import xyz.jimh.souschef.config.SpringContext
 import xyz.jimh.souschef.config.UnitAbbrev
 import xyz.jimh.souschef.config.UnitPreference
 import xyz.jimh.souschef.config.UnitType
@@ -74,7 +73,7 @@ class ShowRecipeControllerTest : ControllerTestBase() {
 
         preferenceDao = mockk()
         Preferences.preferenceDao = preferenceDao
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
 
         every { preferenceDao.findByHostAndKey(any(), "units") } returns
                 Optional.of(Preference("localhost", "units", UnitPreference.ENGLISH.name))

--- a/src/test/kotlin/xyz/jimh/souschef/data/ErrorsTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/data/ErrorsTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll

--- a/src/test/kotlin/xyz/jimh/souschef/display/HtmlElementsTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/display/HtmlElementsTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import xyz.jimh.souschef.ControllerTestBase
-import xyz.jimh.souschef.config.SpringContext
 import xyz.jimh.souschef.config.resetLateInitField
 import xyz.jimh.souschef.control.CategoryController
 import xyz.jimh.souschef.control.EditRecipeControllerTest.Companion.POUND_CAKE_ID
@@ -27,8 +26,8 @@ class HtmlElementsTest : ControllerTestBase() {
         recipeController = mockk()
         categoryController = mockk()
 
-        every { SpringContext.getBean(RecipeController::class.java) } returns recipeController
-        every { SpringContext.getBean(CategoryController::class.java) } returns categoryController
+        every { applicationContext.getBean(RecipeController::class.java) } returns recipeController
+        every { applicationContext.getBean(CategoryController::class.java) } returns categoryController
     }
 
     @AfterEach

--- a/src/test/kotlin/xyz/jimh/souschef/display/IngredientFormatterTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/display/IngredientFormatterTest.kt
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import xyz.jimh.souschef.ControllerTestBase
 import xyz.jimh.souschef.config.Preferences
-import xyz.jimh.souschef.config.SpringContext
 import xyz.jimh.souschef.config.UnitAbbrev
 import xyz.jimh.souschef.config.UnitType
 import xyz.jimh.souschef.data.AUnit
@@ -96,7 +95,7 @@ class IngredientFormatterTest : ControllerTestBase() {
     fun `write Unit as full name`() {
         val preferenceDao = mockk<PreferenceDao>()
         Preferences.preferenceDao = preferenceDao
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
 
         val pref = Preference(HOST, "unitNames", UnitAbbrev.FULL_NAME.name)
         every { preferenceDao.findByHostAndKey(HOST, "unitNames") } returns Optional.of(pref)
@@ -134,7 +133,7 @@ class IngredientFormatterTest : ControllerTestBase() {
     fun `prefer abbrev but still write full name`() {
         val preferenceDao = mockk<PreferenceDao>()
         Preferences.preferenceDao = preferenceDao
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
 
         val pref = Preference(HOST, "unitNames", UnitAbbrev.ABBREVIATION.name)
         every { preferenceDao.findByHostAndKey(HOST, "unitNames") } returns Optional.of(pref)
@@ -171,7 +170,7 @@ class IngredientFormatterTest : ControllerTestBase() {
     fun `write Unit as abbreviation`() {
         val preferenceDao = mockk<PreferenceDao>()
         Preferences.preferenceDao = preferenceDao
-        every { SpringContext.getBean(PreferenceDao::class.java) } returns preferenceDao
+        every { applicationContext.getBean(PreferenceDao::class.java) } returns preferenceDao
 
         val pref = Preference(HOST, "unitNames", UnitAbbrev.ABBREVIATION.name)
         every { preferenceDao.findByHostAndKey(HOST, "unitNames") } returns Optional.of(pref)

--- a/src/test/kotlin/xyz/jimh/souschef/info/HostInfoTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/info/HostInfoTest.kt
@@ -5,7 +5,6 @@ import org.apache.commons.lang3.RandomStringUtils
 import org.apache.commons.lang3.RandomUtils
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.actuate.info.Info
 
 class HostInfoTest {

--- a/src/test/kotlin/xyz/jimh/souschef/info/RecipeCountTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/info/RecipeCountTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.actuate.info.Info
 import xyz.jimh.souschef.data.CategoryCount
 import xyz.jimh.souschef.data.CountDao

--- a/src/test/kotlin/xyz/jimh/souschef/info/UpTimeInfoTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/info/UpTimeInfoTest.kt
@@ -3,7 +3,6 @@ package xyz.jimh.souschef.info
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.actuate.info.Info
 
 class UpTimeInfoTest {

--- a/src/test/kotlin/xyz/jimh/souschef/parse/RecipeParserTest.kt
+++ b/src/test/kotlin/xyz/jimh/souschef/parse/RecipeParserTest.kt
@@ -5,10 +5,10 @@ import io.mockk.mockk
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.StringReader
-import java.util.*
+import java.util.Optional
 import kotlin.io.encoding.ExperimentalEncodingApi
-import kotlin.test.assertNotNull
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -19,7 +19,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.test.util.AssertionErrors.assertNull
 import xyz.jimh.souschef.ControllerTestBase
 import xyz.jimh.souschef.config.Preferences
-import xyz.jimh.souschef.config.SpringContext
 import xyz.jimh.souschef.config.UnitPreference
 import xyz.jimh.souschef.config.resetLateInitField
 import xyz.jimh.souschef.control.UnitController
@@ -53,10 +52,10 @@ class RecipeParserTest : ControllerTestBase() {
         resetLateInitField(IngredientBuilder, "ingredientFormatter")
         resetLateInitField(IngredientBuilder, "unitController")
 
-        every { SpringContext.getBean(IngredientFormatter::class.java) } returns ingredientFormatter
-        every { SpringContext.getBean(UnitDao::class.java) } returns unitDao
-        every { SpringContext.getBean(UnitController::class.java) } returns unitController
-        every { SpringContext.getBean(CategoryDao::class.java) } returns categoryDao
+        every { applicationContext.getBean(IngredientFormatter::class.java) } returns ingredientFormatter
+        every { applicationContext.getBean(UnitDao::class.java) } returns unitDao
+        every { applicationContext.getBean(UnitController::class.java) } returns unitController
+        every { applicationContext.getBean(CategoryDao::class.java) } returns categoryDao
 
         every { categoryDao.findAllByIdNotNullOrderByName() } returns categoryList
         every { unitDao.findAll() } returns UnitControllerTest.unitList
@@ -158,7 +157,7 @@ class RecipeParserTest : ControllerTestBase() {
 
         assertAll(
             { assertNull("response body does not exist", response.body) },
-            { assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.statusCode)}
+            { assertEquals(HttpStatus.UNPROCESSABLE_CONTENT, response.statusCode)}
         )
     }
 


### PR DESCRIPTION
This pull request refactors how Spring beans are accessed throughout the codebase by updating the `SpringContext` utility and replacing class-based bean lookups with a simplified, reified generic approach. It also updates some HTTP status codes for better semantic accuracy and includes minor improvements to comments and documentation.

### Dependency Injection Refactor

* `SpringContext` is refactored from an `ApplicationContextAware` object to a singleton class with a companion object, providing a reified generic `getBean()` method for type-safe and concise bean retrieval. All usages of `SpringContext.getBean(SomeClass::class.java)` are replaced with the new `SpringContext.getBean<SomeClass>()` form, simplifying bean access throughout the codebase.
* Updated bean lookups in `Preferences`, `HtmlElements`, `IngredientBuilder`, and `IngredientParser` to use the new generic `SpringContext.getBean()` method, reducing verbosity and improving maintainability. [[1]](diffhunk://#diff-3672fddd4d54384a998e38e6e0872ce9d060f7c0071202b7aeb4f1e382df2132L194-R194) [[2]](diffhunk://#diff-52bde1b6e5c7e877ba8deb6bb4def41e6484c8e59d8b0b86f9ccf74f98b4f486L68-R71) [[3]](diffhunk://#diff-8cc59ac2880a1eb96dbf169991267790036f6cc2eb8f9c45e9154a9e89ceeeeaL108-R120) [[4]](diffhunk://#diff-654bd65655ddb1c03f20cf84cc0635a5115f1481e5d140d6e51a8554c56a69c3L170-R170)

### HTTP Status Code Corrections

* Changed HTTP status from `UNPROCESSABLE_ENTITY` to `UNPROCESSABLE_CONTENT` in both `EditRecipeController` and `RecipeParser` to better reflect the nature of the error responses. [[1]](diffhunk://#diff-48b2241f381e4a3a698fcd9d78bde8791259f93d3fbcbf67613dec6228b821e3L423-R423) [[2]](diffhunk://#diff-df20960c718faba174e78e42988a3243241dc3ac39cdc20508d5a0337fb254eeL225-R225)

### Documentation and Comment Improvements

* Improved clarity and formatting in comments and documentation within `RecipeParser`, including better explanations of parsing logic and minor grammar corrections. [[1]](diffhunk://#diff-df20960c718faba174e78e42988a3243241dc3ac39cdc20508d5a0337fb254eeL43-R43) [[2]](diffhunk://#diff-df20960c718faba174e78e42988a3243241dc3ac39cdc20508d5a0337fb254eeL155-R155) [[3]](diffhunk://#diff-df20960c718faba174e78e42988a3243241dc3ac39cdc20508d5a0337fb254eeL247-R249) [[4]](diffhunk://#diff-df20960c718faba174e78e42988a3243241dc3ac39cdc20508d5a0337fb254eeL265-R265)